### PR TITLE
Add license information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
   },
   "scripts": {
     "test": "vows; echo"
-  }
+  },
+  "license": "BSD"
 }


### PR DESCRIPTION
Adds the license information to the `package.json`, so that it becomes visible and searchable in `npm`.