### PR TITLE
Don't transform points two times in presimplify

### DIFF
--- a/src/presimplify.js
+++ b/src/presimplify.js
@@ -23,8 +23,7 @@ export default function(topology, triangleArea) {
     // Infinity will be computed in the next step.
     for (i = 0, n = arc.length; i < n; ++i) {
       p = arc[i];
-      arc[i] = [p[0], p[1], Infinity, p[0], p[1]]
-      absolute(arc[i], i);
+      absolute(arc[i] = [p[0], p[1], Infinity], i);
     }
 
     for (i = 1, n = arc.length - 1; i < n; ++i) {
@@ -64,10 +63,7 @@ export default function(topology, triangleArea) {
       }
     }
 
-    for (i = 0, n = arc.length, p; i < n; ++i) {
-      p = arc[i];
-      arc[i] = [p[3], p[4], p[2]]
-    }
+    arc.forEach(relative);
   });
 
   function update(triangle) {

--- a/src/presimplify.js
+++ b/src/presimplify.js
@@ -23,7 +23,8 @@ export default function(topology, triangleArea) {
     // Infinity will be computed in the next step.
     for (i = 0, n = arc.length; i < n; ++i) {
       p = arc[i];
-      absolute(arc[i] = [p[0], p[1], Infinity], i);
+      arc[i] = [p[0], p[1], Infinity, p[0], p[1]]
+      absolute(arc[i], i);
     }
 
     for (i = 1, n = arc.length - 1; i < n; ++i) {
@@ -63,7 +64,10 @@ export default function(topology, triangleArea) {
       }
     }
 
-    arc.forEach(relative);
+    for (i = 0, n = arc.length, p; i < n; ++i) {
+      p = arc[i];
+      arc[i] = [p[3], p[4], p[2]]
+    }
   });
 
   function update(triangle) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -25,8 +25,8 @@ export function relative(transform) {
       dy = transform.translate[1];
   return function(point, i) {
     if (!i) x0 = y0 = 0;
-    var x1 = (point[0] - dx) / kx | 0,
-        y1 = (point[1] - dy) / ky | 0;
+    var x1 = Math.round((point[0] - dx) / kx),
+        y1 = Math.round((point[1] - dy) / ky);
     point[0] = x1 - x0;
     point[1] = y1 - y0;
     x0 = x1;


### PR DESCRIPTION
I was working with a topojson, where d3.geo.bounds got abnormal results. I think the two coordinates loose precision when you transform them to absolute and then back to relative. This PR fixes the issue for me.